### PR TITLE
MOEN-45590: Adopt Swift concurrency isolation in destination

### DIFF
--- a/CODE_STANDARD.md
+++ b/CODE_STANDARD.md
@@ -1,0 +1,88 @@
+# Segment-MoEngage — Code Standards
+
+Conventions for the **Segment-MoEngage** integration. This is a thin wrapper that bridges the
+[Segment Analytics-Swift](https://github.com/segmentio/analytics-swift) SDK to the MoEngage native
+iOS SDK, so it follows the MoEngage native SDK's conventions where they apply, and Segment's
+`DestinationPlugin` conventions at the integration boundary. Where a rule conflicts with habit, this
+document wins.
+
+## Table of Contents
+
+1. [Grammar and Spelling](#1-grammar-and-spelling)
+2. [Naming](#2-naming)
+3. [API Visibility and Obj-C Interop](#3-api-visibility-and-obj-c-interop)
+4. [Optionals and Safety](#4-optionals-and-safety)
+5. [Dependencies](#5-dependencies)
+6. [Testing](#6-testing)
+7. [Formatting](#7-formatting)
+
+---
+
+## 1. Grammar and Spelling
+
+- Spell every word correctly; a misspelled public name is a permanent, breaking-to-fix scar. Run a
+  spell-check pass before a PR.
+- Use **US spelling** (`initialization`, `behavior`, `color`).
+- Boolean names read as a predicate: `is`, `has`, `can`, `should`, `was`.
+- Follow Swift's initialism casing — acronyms are uniformly cased (`SDK`, `URL`, `ID`, `JSON`), not
+  `Sdk`/`Json`.
+
+## 2. Naming
+
+- **Public MoEngage-facing types use the `MoEngage` prefix** and match the native SDK's style
+  (e.g. `MoEngageDestination`). File names match the primary type.
+- At the Segment boundary, follow Segment's plugin conventions (`DestinationPlugin`, `PluginType`,
+  `Timeline`) rather than renaming them.
+- Methods are `camelCase` verb phrases; prefer clear call sites per the
+  [Swift API Design Guidelines](https://www.swift.org/documentation/api-design-guidelines/). Do not
+  prefix simple accessors with `get`.
+- Group members with `// MARK: -` sections.
+
+## 3. API Visibility and Obj-C Interop
+
+- Give every declaration an explicit access level; prefer the **most restrictive** that works. Keep
+  the public surface as small as the Segment plugin contract requires.
+- Use `@objc(...)` where the type must be discoverable from the Obj-C runtime (as `MoEngageDestination`
+  does), and only there.
+- Use `public internal(set)` for properties that integrators read but only the integration mutates.
+
+## 4. Optionals and Safety
+
+- Prefer `guard let … else { return }` early exits over nested `if let`.
+- Prefer optional chaining (`?.`) and nil-coalescing (`??`) over `x != nil` checks.
+- **Do not force-unwrap (`!`) or `as!`** in new code; if unavoidable, comment why it cannot be nil.
+- Never let an error from the integration crash the host app — handle failures with `do`/`try`/`catch`
+  and fail safe.
+
+## 5. Dependencies
+
+- Depend **only** on the Segment Analytics-Swift SDK and the MoEngage native iOS SDK. Do not add
+  unrelated third-party dependencies.
+- The compatible native SDK range is declared in [package.json](package.json) (`sdkVerMin` /
+  `sdkVerMax`) and mirrored in [Package.swift](Package.swift); keep them in sync when bumping.
+
+## 6. Testing
+
+- Tests live under [Tests/](Tests/) and use **XCTest** (`import XCTest`).
+- Name tests `test_<subject>_<condition>_<expectation>()` so the intent is greppable.
+- Run the suite with `rake test`, and verify behavioural changes in the sample apps (SPM / Tuist /
+  Manual) per [CONTRIBUTING.md](CONTRIBUTING.md#building-and-testing).
+
+## 7. Formatting
+
+- There is no SwiftLint config in this repo — follow the existing style: `MoEngage`-prefixed public
+  types, `// MARK: -` sections, and consistent indentation matching the surrounding code.
+- Add a file header to new files; prefer the standard MoEngage copyright header:
+
+  ```swift
+  //
+  //  <FileName>.swift
+  //  Segment-MoEngage
+  //
+  //  Created by <Author> on <dd/MM/yy>.
+  //  Copyright © <Year> MoEngage. All rights reserved.
+  //
+  ```
+
+- Comment only when the **why** isn't obvious from the code (a Segment/mParticle quirk, an ordering
+  constraint). Don't restate what the code does or reference Jira tickets in comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,86 +1,160 @@
-# Contributing to MoEngageSegment
+# Contributing Guidelines
 
-Thank you for your interest in contributing to the MoEngageSegment project! This guide will help you understand the project structure and get you started with development.
+Thank you for your interest in contributing to the **Segment-MoEngage** integration! This is the
+MoEngage integration for the [Segment (Twilio) Analytics-Swift](https://github.com/segmentio/analytics-swift)
+SDK. It wraps the MoEngage native iOS SDK so Segment customers can route events to MoEngage.
+
+## Table of Contents
+
+- [Branching Strategy](#branching-strategy)
+- [Project Structure](#project-structure)
+  - [Sample Apps](#sample-apps)
+  - [Extensions](#extensions)
+- [Development / Testing Setup](#development--testing-setup)
+- [Building and Testing](#building-and-testing)
+- [General Guidelines](#general-guidelines)
+- [Changelog](#changelog)
+  - [Header](#header)
+- [Raising a Pull Request](#raising-a-pull-request)
+
+## Branching Strategy
+
+Create your branch from an up-to-date `development` branch. Only if your change depends on another
+in-flight change should you branch off that branch instead.
+
+Branch names follow the standard MoEngage
+[branching guidelines](https://moengagetrial.atlassian.net/wiki/spaces/EN/pages/5919277067/Branching+StrategyReleaseProcess):
+a prefix, the Jira ticket id, then a short readable description separated by an underscore.
+
+Example - `feature/MOEN-1234_segment-event-mapping`
+
+All pull requests are raised against `development`.
 
 ## Project Structure
 
-The project is built using Tuist and consists of several targets:
+The workspace is generated with [Tuist](https://github.com/tuist/tuist). The integration source
+lives under [Sources/Segment-MoEngage](Sources/Segment-MoEngage); sample apps and extensions live
+under [Examples/](Examples/).
 
 ### Sample Apps
 
 #### MoEngageSPMApp
-- **Purpose**: Sample app using Swift Package Manager for dependency management
-- **Dependencies**: 
-  - Segment-MoEngage (via SPM)
-  - MoEngageRichNotification (via SPM)
-  - NotificationService extension
-  - NotificationContent extension
-- **Setup**: 
-  - Use this app to test the Swift Package Manager integration (default integration mode for customer)
-  - Make sure SPM dependencies are enabled and Tuist dependencies are disabled for extension targets
+- **Purpose**: Sample app using Swift Package Manager for dependency management.
+- **Dependencies**: Segment-MoEngage (via SPM), MoEngageRichNotification (via SPM),
+  NotificationService extension, NotificationContent extension.
+- **Setup**: Use this app to test the Swift Package Manager integration (the default integration mode
+  for customers). Make sure SPM dependencies are enabled and Tuist dependencies are disabled for
+  extension targets.
 
 #### MoEngageTuistApp
-- **Purpose**: Main sample app built with Tuist to test native SDK changes before release
-- **Dependencies**: 
-  - Segment-MoEngage (via Tuist)
-  - MoEngageRichNotification (via Tuist)
-  - NotificationService extension
-  - NotificationContent extension
-- **Setup**:
-  - This app demonstrates the full integration of MoEngage with Segment, including rich notifications
-  - Make sure Tuist dependencies are enabled and SPM dependencies are disabled for extension targets
+- **Purpose**: Main sample app built with Tuist to test native SDK changes before release.
+- **Dependencies**: Segment-MoEngage (via Tuist), MoEngageRichNotification (via Tuist),
+  NotificationService extension, NotificationContent extension.
+- **Setup**: Demonstrates the full integration of MoEngage with Segment, including rich
+  notifications. Make sure Tuist dependencies are enabled and SPM dependencies are disabled for
+  extension targets.
 
 #### MoEngageManualApp
-- **Purpose**: Sample app with manual integration of frameworks (XCFrameworks)
-- **Dependencies**: Manually add XCFramework dependencies as [described](README.md#manual-integration).
-- **Setup**: 
-  - Add the required XCFrameworks to this target for testing manual integration
-  - Make sure Tuist and SPM dependencies are disabled for extension targets, manually add XCFrameworks to extensions with `Do not embed` option.
+- **Purpose**: Sample app with manual integration of frameworks (XCFrameworks).
+- **Dependencies**: Manually added XCFramework dependencies as [described](README.md#manual-integration).
+- **Setup**: Add the required XCFrameworks to this target for testing manual integration. Make sure
+  Tuist and SPM dependencies are disabled for extension targets, and manually add XCFrameworks to
+  extensions with the `Do not embed` option.
 
 ### Extensions
 
 #### NotificationService
-- **Purpose**: Notification service extension for rich push notifications and impression tracking
-- **Dependencies**: 
-  - MoEngage-iOS-SDK (via SPM/Tuist)
-  - MoEngageRichNotification (via SPM/Tuist)
-- **Setup**: This extension handles downloading media attachments for rich push notifications and notification delivery tracking
+- **Purpose**: Notification service extension for rich push notifications and impression tracking.
+- **Dependencies**: MoEngage-iOS-SDK (via SPM/Tuist), MoEngageRichNotification (via SPM/Tuist).
+- **Setup**: Handles downloading media attachments for rich push notifications and notification
+  delivery tracking.
 
 #### NotificationContent
-- **Purpose**: Notification content extension for custom notification UI
-- **Dependencies**: 
-  - MoEngage-iOS-SDK (via SPM/Tuist)
-  - MoEngageRichNotification (via SPM/Tuist)
-- **Setup**: This extension enables custom notification interfaces
+- **Purpose**: Notification content extension for custom notification UI.
+- **Dependencies**: MoEngage-iOS-SDK (via SPM/Tuist), MoEngageRichNotification (via SPM/Tuist).
+- **Setup**: Enables custom notification interfaces.
 
-## Development or Testing Setup
+## Development / Testing Setup
 
-1. Clone the repository
-  - Run `git reset--hard` when running with existing clone. 
-1. Run `rake setup` to generate the Xcode projects
-1. Replace XCFrameworks in [`Examples/Tuist/.build/artifacts`](Examples/Tuist/.build/artifacts) if required.
-1. Open the generated `Examples/MoEngageSegment.xcworkspace` file
-1. Change team to your team to run the app on device.
+1. Clone the repository.
+   - When re-using an existing clone, run `git reset --hard` first so the generated project is
+     regenerated cleanly.
+2. Run `rake setup` to install Tuist (if needed) and generate the Xcode projects.
+3. Replace XCFrameworks in [`Examples/Tuist/.build/artifacts`](Examples/Tuist/.build/artifacts) if
+   required (e.g. to test against a local native SDK build).
+4. Open the generated `Examples/MoEngageSegment.xcworkspace`.
+5. Change the signing team to your team to run on a device.
+
+> Run `rake -D` to see all supported tasks, and `rake -D setup` for setup options.
 
 ## Building and Testing
 
-- Select the appropriate scheme based on what you want to test:
-  - `MoEngageSPMApp` for SPM integration
-  - `MoEngageTuistApp` for Tuist integration
-  - `MoEngageManualApp` for manual XCFramework integration
+- Select the scheme for what you want to test:
+  - `MoEngageSPMApp` — SPM integration
+  - `MoEngageTuistApp` — Tuist integration
+  - `MoEngageManualApp` — manual XCFramework integration
+- Run the unit tests with `rake test`.
+- Build the XCFrameworks with `rake xcframework`.
 
-## Making Contributions
+All apps use iOS 13.0 as the minimum deployment target and share common settings for code signing
+and versioning.
 
-1. Create a new branch for your feature or bugfix,
-  - branch name should have ticket id prefix with and underscore separating ticket id from readable name
-1. Make your changes
-1. Test with the appropriate sample app
-1. Submit a pull request to `development` branch with a detailed description of your changes
+## General Guidelines
 
-## Project Settings
+- **Keep dependencies minimal.** This integration should depend only on the Segment
+  Analytics-Swift SDK and the MoEngage native iOS SDK. Do not add unrelated third-party
+  dependencies.
+- **Match the native SDK's conventions.** Types and public APIs use the `MoEngage` prefix, file names
+  match the primary type, and code uses `// MARK: -` sections and consistent indentation.
+- **Deprecations:** if any public or client-facing API is deprecated or removed, mark it with
+  `@available(*, deprecated, message: ...)` and note it in the [changelog](#changelog) with the new
+  API equivalent.
+- **Copyright header:** add the standard MoEngage copyright header to the top of every new file.
+- **Guard against runtime failures.** Handle errors with `do`/`try`/`catch`; never let an exception
+  from the integration crash the host app.
 
-All apps use iOS 13.0 as the minimum deployment target and share common settings for code signing and versioning.
+## Changelog
 
-## Additional Resources
+Every change adds an entry to the root [CHANGELOG.md](CHANGELOG.md). The version is tracked in
+[package.json](package.json) (`frameworks[].version`).
 
-See the project's README.md for more information on usage and requirements.
+> You do not need to fill in the release date or version manually — the release pipeline replaces the
+> placeholder header with the actual date and version at release time (producing entries like
+> `# 29-06-2026` / `## 2.13.0`). Your job is to add the entry bullet under the unreleased header.
+
+### Header
+
+Below is the header you need to add to the changelog file if it is not present already. If the header
+is already present, do not add it again — just add your bullet under it.
+
+```
+# Release Date
+
+## Release Version
+
+```
+
+Add your entry as a bullet under this header:
+
+```
+- <customer-readable description of the change>
+- Updated MoEngage-iOS-SDK to <version>   # when the native SDK dependency is bumped
+```
+
+Most releases of this integration are native-SDK dependency bumps; describe any behavioural change to
+the Segment mapping itself in its own bullet.
+
+## Raising a Pull Request
+
+Before raising a pull request, verify the following:
+
+- The workspace generates cleanly (`rake setup`).
+- The integration builds (`rake xcframework`).
+- Unit tests pass (`rake test`).
+- The change is verified in the appropriate sample app (SPM / Tuist / Manual).
+- [CHANGELOG.md](CHANGELOG.md) is updated under the unreleased header.
+
+Raise the PR against `development` with a detailed description. The PR title should be
+`MOEN-<TICKET_NUMBER> : <short description of the change>`.
+
+For the release process, see [RELEASING.md](RELEASING.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,12 +1,64 @@
-Releasing
-=========
+# Release Process
 
-1. Make sure CHANGELOG for each module is up to date, from the CHANGELOGs determine the new version to be released.
-1. Create [developer docs release notes entry](https://developers.moengage.com/hc/en-us/articles/13578297907220-iOS-Swift-Changelog) for the new release.
-1. Trigger workflow [`cd.yml`](.github/workflows/cd.yml) from development branch with input:
-    - note: as the link to new release note entry created in previous step.
-    - ticket: as the release ticket id.
-    - sdk-version: as the minimum SDK version (if dependency needs to be updated).
+The **Segment-MoEngage** integration is released through its own [`cd.yml`](.github/workflows/cd.yml)
+GitHub Actions workflow, which runs on the shared MoEngage release pipeline. Trigger it with the
+`gh` CLI; if `gh` is not authenticated, run `gh auth login` first. If the workflow fails with a
+permission error, share the exact command with **@msoumya-engg-sdk** or **@umangmoe** to run it
+manually.
 
-> [!NOTE]
-> Follow doc for latest steps: https://moengagetrial.atlassian.net/wiki/spaces/MS/pages/3581215076/iOS+SDK+release+steps#Partner-release-steps-(applicable-to-PluginBase%2C-Segment-and-mParticle-SDK)
+> **You do not need to edit the release date or version manually** in [CHANGELOG.md](CHANGELOG.md) or
+> [package.json](package.json). The pipeline replaces the unreleased placeholder header with the
+> actual date and version, tags the release, and publishes the XCFrameworks/SPM release.
+
+> **Distribution:** this integration is distributed via **Swift Package Manager** and **manual
+> XCFramework** integration (see [README.md](README.md)) — it is not published to CocoaPods.
+
+## Pre-flight
+
+Do these before triggering the release:
+
+1. Ensure [CHANGELOG.md](CHANGELOG.md) is up to date under the unreleased header (see
+   [CONTRIBUTING.md](CONTRIBUTING.md#changelog)).
+2. Create the [developer-docs release-notes entry](https://developers.moengage.com/hc/en-us/articles/13578297907220-iOS-Swift-Changelog)
+   for the new version and keep its URL for the `note` input.
+3. Decide whether the MoEngage native SDK dependency needs bumping. The compatible range lives in
+   [package.json](package.json) (`sdkVerMin` / `sdkVerMax`); pass `sdk-version` only when raising the
+   minimum.
+4. Ensure `ci.yml` is green on `development`.
+
+## Trigger the release
+
+```bash
+gh workflow run cd.yml \
+  --repo moengage/MoEngage-Segment-Swift \
+  --ref development \
+  -f ticket="MOEN-XXXXX" \
+  -f note="<RELEASE_NOTE_URL>" \
+  -f sdk-version="<MIN_NATIVE_SDK_VERSION_OR_OMIT>"
+```
+
+- `ticket` — the release ticket id (required).
+- `note` — the release-notes URL from pre-flight step 2 (required).
+- `sdk-version` — the new minimum native SDK version; **omit** unless bumping the dependency.
+
+## Monitor
+
+```bash
+gh run list  --repo moengage/MoEngage-Segment-Swift --workflow cd.yml --limit 1
+gh run watch <RUN_ID> --repo moengage/MoEngage-Segment-Swift
+```
+
+## Verify
+
+```bash
+gh release list --repo moengage/MoEngage-Segment-Swift --limit 3
+gh release view <VERSION> --repo moengage/MoEngage-Segment-Swift
+```
+
+Confirm the new version tag exists and the XCFramework assets are attached to the GitHub release, then
+verify SPM resolution from the sample app (`MoEngageSPMApp`).
+
+## Reference
+
+Follow the canonical steps for the latest process:
+[iOS SDK release steps — Partner release](https://moengagetrial.atlassian.net/wiki/spaces/MS/pages/3581215076/iOS+SDK+release+steps#Partner-release-steps-(applicable-to-PluginBase%2C-Segment-and-mParticle-SDK)).

--- a/Rakefile
+++ b/Rakefile
@@ -42,13 +42,21 @@ desc <<~DESC
 DESC
 task :xcframework => [PROJECT, config.xcframework.workspace] do |t, args|
   require 'net/http'
+  common_script = URI('https://raw.githubusercontent.com/moengage/sdk-automation-scripts/refs/heads/master/scripts/release/ios/common.rb')
+  common_req = Net::HTTP::Get.new(common_script.request_uri)
+  common_req['Authorization'] = "Bearer #{ENV['GITHUB_TOKEN']}"
+  common_http = Net::HTTP.new(common_script.host, common_script.port)
+  common_http.use_ssl = true
+  common_res = common_http.request(common_req)
   xcframework_script = URI('https://raw.githubusercontent.com/moengage/sdk-automation-scripts/refs/heads/master/scripts/release/ios/xcframework.rb')
-  req = Net::HTTP::Get.new(xcframework_script.request_uri)
-  req['Authorization'] = "Bearer #{ENV['GITHUB_TOKEN']}"
-  http = Net::HTTP.new(xcframework_script.host, xcframework_script.port)
-  http.use_ssl = true
-  res = http.request(req)
-  eval(res.body)
+  xcframework_req = Net::HTTP::Get.new(xcframework_script.request_uri)
+  xcframework_req['Authorization'] = "Bearer #{ENV['GITHUB_TOKEN']}"
+  xcframework_http = Net::HTTP.new(xcframework_script.host, xcframework_script.port)
+  xcframework_http.use_ssl = true
+  xcframework_res = xcframework_http.request(xcframework_req)
+  script = xcframework_res.body
+  script.gsub!("require_relative 'common'", "\n#{common_res.body}\n")
+  eval(script)
 end
 
 desc <<~DESC

--- a/Sources/Segment-MoEngage/MoEngageDestination.swift
+++ b/Sources/Segment-MoEngage/MoEngageDestination.swift
@@ -3,19 +3,18 @@ import MoEngageSDK
 import UIKit
 
 @objc(MoEngageDestination)
-public class MoEngageDestination: UIResponder, DestinationPlugin, MoEngagePartnerIntegrationHandler.Integrator {
+public class MoEngageDestination: UIResponder, DestinationPlugin, MoEngageConfig.Partner.IntegrationHandler.Integrator {
     public let timeline = Timeline()
     public let type = PluginType.destination
     public let key = MoEngageDestinationConstant.destinationKey
     
     public var analytics: Analytics?
     private var moengageSettings: MoEngageSettings?
-    private let handler = MoEngagePartnerIntegrationHandler(type: .segment)
+    private let handler = MoEngageConfig.Partner.IntegrationHandler(type: .segment)
 
-    public override init() {
-    }
+    public nonisolated override init() {}
     
-    public func update(settings: Settings, type: UpdateType) {
+    public nonisolated func update(settings: Settings, type: UpdateType) {
         guard
           let tempSettings: MoEngageSettings = settings.integrationSettings(forPlugin: self),
           moengageSettings?.apiKey != tempSettings.apiKey, // allow update only if workspace id has changed
@@ -31,7 +30,7 @@ public class MoEngageDestination: UIResponder, DestinationPlugin, MoEngagePartne
         self.enabled(forWorkspaceId: workspaceId)
     }
 
-    public func enabled(forWorkspaceId workspaceId: String) {
+    public nonisolated func enabled(forWorkspaceId workspaceId: String) {
         DispatchQueue.main.async {
             if let segmentAnonymousID = self.analytics?.anonymousId {
                 MoEngageSDKAnalytics.sharedInstance.setUserAttribute(segmentAnonymousID, withAttributeName: MoEngageDestinationConstant.segmentAnonymousIDAttribute, forAppID: workspaceId)
@@ -40,16 +39,16 @@ public class MoEngageDestination: UIResponder, DestinationPlugin, MoEngagePartne
     }
 
     public func identify(event: IdentifyEvent) -> IdentifyEvent? {
-        var actions: [(String) -> Void] = []
+        var actions: [(String, isolated MoEngageSDKInstance) -> Void] = []
         if let userId = event.userId, !userId.isEmpty {
-            actions.append { MoEngageSDKAnalytics.sharedInstance.identifyUser(identity: userId, workspaceId: $0) }
+            actions.append { MoEngageSDKAnalytics.sharedInstance.identifyUser(identity: userId, workspaceId: $0, isolation: $1) }
         }
 
         if let segmentAnonymousID = self.analytics?.anonymousId {
             actions.append {
                 MoEngageSDKAnalytics.sharedInstance.setUserAttribute(
                     segmentAnonymousID, withAttributeName: MoEngageDestinationConstant.segmentAnonymousIDAttribute,
-                    forAppID: $0
+                    forAppID: $0, isolation: $1
                 )
             }
         }
@@ -58,68 +57,68 @@ public class MoEngageDestination: UIResponder, DestinationPlugin, MoEngagePartne
             if let birthday = traits[UserAttributes.birthday.rawValue] as? NSNumber {
                 let timeInterval = TimeInterval(birthday.doubleValue)
                 let formattedBirthday = Date(timeIntervalSinceReferenceDate: timeInterval)
-                actions.append { MoEngageSDKAnalytics.sharedInstance.setDateOfBirth(formattedBirthday, forAppID: $0) }
+                actions.append { MoEngageSDKAnalytics.sharedInstance.setDateOfBirth(formattedBirthday, forAppID: $0, isolation: $1) }
                 traits.removeValue(forKey: UserAttributes.birthday.rawValue)
             } else if let birthday = traits[UserAttributes.birthday.rawValue] as? Date {
-                actions.append { MoEngageSDKAnalytics.sharedInstance.setDateOfBirth(birthday, forAppID: $0) }
+                actions.append { MoEngageSDKAnalytics.sharedInstance.setDateOfBirth(birthday, forAppID: $0, isolation: $1) }
                 traits.removeValue(forKey: UserAttributes.birthday.rawValue)
             } else if let birthdayStr = traits[UserAttributes.birthday.rawValue] as? String, let birthday = self.date(fromISOdateStr: birthdayStr) {
-                actions.append { MoEngageSDKAnalytics.sharedInstance.setDateOfBirth(birthday, forAppID: $0) }
+                actions.append { MoEngageSDKAnalytics.sharedInstance.setDateOfBirth(birthday, forAppID: $0, isolation: $1) }
                 traits.removeValue(forKey: UserAttributes.birthday.rawValue)
             }
 
             if let name = traits[UserAttributes.name.rawValue] as? String {
-                actions.append { MoEngageSDKAnalytics.sharedInstance.setName(name, forAppID: $0) }
+                actions.append { MoEngageSDKAnalytics.sharedInstance.setName(name, forAppID: $0, isolation: $1) }
                 traits.removeValue(forKey: UserAttributes.name.rawValue)
             }
             if let birthday = traits[UserAttributes.isoBirthday.rawValue] as? String {
-                actions.append { MoEngageSDKAnalytics.sharedInstance.setDateOfBirthInISO(birthday, forAppID: $0) }
+                actions.append { MoEngageSDKAnalytics.sharedInstance.setDateOfBirthInISO(birthday, forAppID: $0, isolation: $1) }
                 traits.removeValue(forKey: UserAttributes.isoBirthday.rawValue)
             }
             
             if let email = traits[UserAttributes.email.rawValue] as? String {
-                actions.append { MoEngageSDKAnalytics.sharedInstance.setEmailID(email, forAppID: $0) }
+                actions.append { MoEngageSDKAnalytics.sharedInstance.setEmailID(email, forAppID: $0, isolation: $1) }
                 traits.removeValue(forKey: UserAttributes.email.rawValue)
             }
             
             if let firstName = traits[UserAttributes.firstName.rawValue] as? String {
-                actions.append { MoEngageSDKAnalytics.sharedInstance.setFirstName(firstName, forAppID: $0) }
+                actions.append { MoEngageSDKAnalytics.sharedInstance.setFirstName(firstName, forAppID: $0, isolation: $1) }
                 traits.removeValue(forKey: UserAttributes.firstName.rawValue)
             }
             
             if let lastName = traits[UserAttributes.lastName.rawValue] as? String {
-                actions.append { MoEngageSDKAnalytics.sharedInstance.setLastName(lastName, forAppID: $0) }
+                actions.append { MoEngageSDKAnalytics.sharedInstance.setLastName(lastName, forAppID: $0, isolation: $1) }
                 traits.removeValue(forKey: UserAttributes.lastName.rawValue)
             }
             
             if let gender = (traits[UserAttributes.gender.rawValue] as? String)?.lowercased() {
                 if gender == MoEngageDestinationConstant.m_male || gender == MoEngageDestinationConstant.male {
-                    actions.append { MoEngageSDKAnalytics.sharedInstance.setGender(.male, forAppID: $0) }
+                    actions.append { MoEngageSDKAnalytics.sharedInstance.setGender(.male, forAppID: $0, isolation: $1) }
                 }
                 else if gender == MoEngageDestinationConstant.f_female || gender == MoEngageDestinationConstant.female {
-                    actions.append { MoEngageSDKAnalytics.sharedInstance.setGender(.female, forAppID: $0) }
+                    actions.append { MoEngageSDKAnalytics.sharedInstance.setGender(.female, forAppID: $0, isolation: $1) }
                 }
                 else {
-                    actions.append { MoEngageSDKAnalytics.sharedInstance.setGender(.others, forAppID: $0) }
+                    actions.append { MoEngageSDKAnalytics.sharedInstance.setGender(.others, forAppID: $0, isolation: $1) }
                 }
                 traits.removeValue(forKey: UserAttributes.gender.rawValue)
             }
             
             if let phone = traits[UserAttributes.phone.rawValue] as? String {
-                actions.append { MoEngageSDKAnalytics.sharedInstance.setMobileNumber(phone, forAppID: $0) }
+                actions.append { MoEngageSDKAnalytics.sharedInstance.setMobileNumber(phone, forAppID: $0, isolation: $1) }
                 traits.removeValue(forKey: UserAttributes.phone.rawValue)
             }
             
             if let isoDate = traits[UserAttributes.isoDate.rawValue] as? [String: Any] {
                 if let date = isoDate[MoEngageDestinationConstant.date] as? Date, let attributeName = isoDate[MoEngageDestinationConstant.attributeName] as? String {
-                    actions.append { MoEngageSDKAnalytics.sharedInstance.setUserAttributeDate(date, withAttributeName: attributeName, forAppID: $0) }
+                    actions.append { MoEngageSDKAnalytics.sharedInstance.setUserAttributeDate(date, withAttributeName: attributeName, forAppID: $0, isolation: $1) }
                     traits.removeValue(forKey: UserAttributes.isoDate.rawValue)
                 }
             }
             
             if let location = traits[UserAttributes.location.rawValue] as? [String: Any] {
                 if let latitute = location[MoEngageDestinationConstant.latitude] as? Double, let longitude = location[MoEngageDestinationConstant.longitude] as? Double {
-                    actions.append { MoEngageSDKAnalytics.sharedInstance.setLocation(MoEngageGeoLocation(withLatitude: latitute, andLongitude: longitude), forAppID: $0) }
+                    actions.append { MoEngageSDKAnalytics.sharedInstance.setLocation(MoEngageGeoLocation(withLatitude: latitute, andLongitude: longitude), forAppID: $0, isolation: $1) }
                     traits.removeValue(forKey: UserAttributes.location.rawValue)
                 }
             }
@@ -127,24 +126,25 @@ public class MoEngageDestination: UIResponder, DestinationPlugin, MoEngagePartne
             for trait in traits {
                 switch trait.value {
                 case let val as Date:
-                    actions.append { MoEngageSDKAnalytics.sharedInstance.setUserAttributeDate(val, withAttributeName: trait.key, forAppID: $0) }
+                    actions.append { MoEngageSDKAnalytics.sharedInstance.setUserAttributeDate(val, withAttributeName: trait.key, forAppID: $0, isolation: $1) }
                 case let val as String:
                     guard let date = self.date(fromISOdateStr: val) else { fallthrough }
-                    actions.append { MoEngageSDKAnalytics.sharedInstance.setUserAttributeDate(date, withAttributeName: trait.key, forAppID: $0) }
+                    actions.append { MoEngageSDKAnalytics.sharedInstance.setUserAttributeDate(date, withAttributeName: trait.key, forAppID: $0, isolation: $1) }
                 default:
-                    actions.append { MoEngageSDKAnalytics.sharedInstance.setUserAttribute(trait.value, withAttributeName: trait.key, forAppID: $0) }
+                    actions.append { MoEngageSDKAnalytics.sharedInstance.setUserAttribute(trait.value, withAttributeName: trait.key, forAppID: $0, isolation: $1) }
                 }
             }
         }
 
-        handler.process(integrator: self, forWorkspaceId: moengageSettings?.apiKey) { workspaceId in
+        handler.process(integrator: self, forWorkspaceId: moengageSettings?.apiKey) { sdkInstance in
+            let workspaceId = sdkInstance.config.workspaceId
             for action in actions {
-                action(workspaceId)
+                action(workspaceId, sdkInstance)
             }
         }
         return event
     }
-    
+
     public func track(event: TrackEvent) -> TrackEvent? {
         if var generalAttributeDict = event.properties?.dictionaryValue {
             var dateAttributeDict: [String : Date] = [:]
@@ -166,9 +166,9 @@ public class MoEngageDestination: UIResponder, DestinationPlugin, MoEngagePartne
                     moeProperties.addDateAttribute(dateVal, withName: key)
                 }
             }
-            handler.process(integrator: self, forWorkspaceId: moengageSettings?.apiKey) { workspaceId in
+            handler.process(integrator: self, forWorkspaceId: moengageSettings?.apiKey) { sdkInstance in
                 MoEngageSDKAnalytics.sharedInstance.trackEvent(
-                    event.event, withProperties: moeProperties, forAppID: workspaceId
+                    event.event, withProperties: moeProperties, forAppID: sdkInstance.config.workspaceId
                 )
             }
         }
@@ -187,22 +187,25 @@ public class MoEngageDestination: UIResponder, DestinationPlugin, MoEngagePartne
     
     public func alias(event: AliasEvent) -> AliasEvent? {
         if let userId = event.userId {
-            handler.process(integrator: self, forWorkspaceId: moengageSettings?.apiKey) { workspaceId in
-                MoEngageSDKAnalytics.sharedInstance.identifyUser(identity: userId, workspaceId: workspaceId)
+            handler.process(integrator: self, forWorkspaceId: moengageSettings?.apiKey) { sdkInstance in
+                MoEngageSDKAnalytics.sharedInstance.identifyUser(
+                    identity: userId, workspaceId: sdkInstance.config.workspaceId, isolation: sdkInstance
+                )
             }
         }
         return event
     }
     
     public func flush() {
-        handler.process(integrator: self, forWorkspaceId: moengageSettings?.apiKey) { workspaceId in
-            MoEngageSDKAnalytics.sharedInstance.flush(forAppID: workspaceId)
+        handler.process(integrator: self, forWorkspaceId: moengageSettings?.apiKey) { sdkInstance in
+            MoEngageSDKAnalytics.sharedInstance.flush(forAppID: sdkInstance.config.workspaceId, isolation: sdkInstance)
         }
     }
-    
+
     public func reset() {
-        handler.process(integrator: self, forWorkspaceId: moengageSettings?.apiKey) { workspaceId in
-            MoEngageSDKAnalytics.sharedInstance.resetUser(forAppID: workspaceId) { [weak self] _ in
+        handler.process(integrator: self, forWorkspaceId: moengageSettings?.apiKey) { sdkInstance in
+            let workspaceId = sdkInstance.config.workspaceId
+            MoEngageSDKAnalytics.sharedInstance.resetUser(forAppID: workspaceId, isolation: sdkInstance) { [weak self] _ in
                 self?.enabled(forWorkspaceId: workspaceId)
             }
         }

--- a/Sources/Segment-MoEngage/MoEngageInitializer.swift
+++ b/Sources/Segment-MoEngage/MoEngageInitializer.swift
@@ -25,7 +25,7 @@ public final class MoEngageInitializer: NSObject {
 #else
         MoEngage.sharedInstance.initializeDefaultLiveInstance(sdkConfig)
 #endif
-        trackPluginTypeAndVersion(sdkConfig: sdkConfig)
+        trackPluginTypeAndVersion(sdkConfig: .init(sdkConfig))
     }
 
     /// Method to initialize the default instance of MoEngageSDK
@@ -34,8 +34,8 @@ public final class MoEngageInitializer: NSObject {
         MoEngage.sharedInstance.initializeDefaultInstance()
 
         guard
-            let sdkConfig = try? MoEngageInitialization.fetchSDKConfigurationFromInfoPlist(),
-            !sdkConfig.appId.isEmpty
+            let sdkConfig = try? MoEngageConfig.FileBased.fetchSDKConfigurationFromInfoPlist(),
+            !sdkConfig.workspaceId.isEmpty
         else {
             MoEngageLogger.logDefault(message: "App ID is empty. Please provide a valid App ID to setup the SDK.")
             return
@@ -52,15 +52,15 @@ public final class MoEngageInitializer: NSObject {
 #else
         MoEngage.sharedInstance.initializeLiveInstance(sdkConfig)
 #endif
-        trackPluginTypeAndVersion(sdkConfig: sdkConfig)
+        trackPluginTypeAndVersion(sdkConfig: .init(sdkConfig))
     }
     
     private static func updateSDKConfig(sdkConfig: MoEngageSDKConfig) {
         sdkConfig.setPartnerIntegrationType(integrationType: MoEngagePartnerIntegrationType.segment)
     }
     
-    private static func trackPluginTypeAndVersion(sdkConfig: MoEngageSDKConfig) {
+    private static func trackPluginTypeAndVersion(sdkConfig: MoEngageConfig.Data) {
         let integrationInfo = MoEngageIntegrationInfo(pluginType: .segment, version: MoEngageSegmentConstant.segmentVersion)
-        MoEngageCoreIntegrator.sharedInstance.addIntergrationInfo(info: integrationInfo, appId: sdkConfig.appId)
+        MoEngageCoreIntegrator.sharedInstance.addIntergrationInfo(info: integrationInfo, appId: sdkConfig.workspaceId)
     }
 }


### PR DESCRIPTION
### Jira Ticket
[MOEN-45590](https://moengage.atlassian.net/browse/MOEN-45590)

### Description
Adopts Swift concurrency isolation in the Segment destination to align with the updated MoEngage iOS SDK APIs:

- Pass the isolated `MoEngageSDKInstance` through `identify`/`track`/`alias`/`flush`/`reset` so analytics calls run on the correct actor isolation.
- Mark `init`, `update(settings:type:)`, and `enabled(forWorkspaceId:)` as `nonisolated`.
- Migrate to the new `MoEngageConfig` namespace types (`Partner.IntegrationHandler`, `FileBased`, `Data`) and the `workspaceId` naming (previously `appId`).
- Update `CONTRIBUTING.md` / `RELEASING.md` docs and add `CODE_STANDARD.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MOEN-45590]: https://moengagetrial.atlassian.net/browse/MOEN-45590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ